### PR TITLE
Fix Footnote Numbering

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -30,4 +30,4 @@
       5.4.4  Members of all teams are required to acknowledge the Three-Strike (Filippini) rule upon any team reaching game point by verbally confirming that "The Three-Strike (Filippini) rule is in effect".
   
 Links
-[0] - http://www.ittf.com/ittf_handbook/hb.asp?s_number=2 
+[1] - http://www.ittf.com/ittf_handbook/hb.asp?s_number=2


### PR DESCRIPTION
There was a zero (0) in one place and a one (1) in another.
